### PR TITLE
added CLI arg and ini file parsing and example ini file

### DIFF
--- a/mps_diffusers.py
+++ b/mps_diffusers.py
@@ -27,6 +27,9 @@ from diffusers.schedulers import (
 	ScoreSdeVeScheduler,
 	ScoreSdeVpScheduler,
 )
+from configparser import ConfigParser
+import argparse
+import json
 import random
 import warnings
 import re
@@ -35,22 +38,42 @@ from PIL import Image
 from PIL.PngImagePlugin import PngInfo
 from compel import Compel
 
-width = 512
-height = 512
-model = "runwayml/stable-diffusion-v1-5"
-cfg_scale = 7.5
-steps = 50
-sampler = "dpm_solver_s"
-fp16 = True
+parser = argparse.ArgumentParser(description="AI image gen using diffusers on MPS")
+parser.add_argument('--profile', type=str, help="the profile from profiles.ini to load, omit for default")
+parser.add_argument('-p', metavar='"astronaut, mars"', type=str, help="positive prompt (in quotes)", required=True)
+parser.add_argument('-n', metavar='"goofy hands"', type=str, help="negative prompt (in quotes)")
+args = parser.parse_args()
 
-prompt = "an astronaut fighting a dragon on mars, artstation, 8k, dramatic lighting, detailed, intricate concept art, greg rutkowski"
-neg = "anime, cartoon, stippling"
+conf = ConfigParser()
+conf.read('profiles.ini')
+
+if args.profile and args.profile in conf.sections():
+	choice = args.profile
+else:
+	choice = False
+
+# copy our profile from the .ini, will read from this copy below
+st = dict(conf[choice]) if choice else dict(conf['DEFAULT'])
+
+# this is a hack to cast to type without hardcoding getters
+for k,v in st.items():
+    if v[0].isdigit():
+        try:
+            st[k] = int(v)
+        except ValueError:
+            st[k] = float(v)
+
+# this is because the above hack doesn't cover bools
+st['fp16'] = json.loads(st['fp16'].lower())
+
+prompt = args.p
+neg = args.n or ""
 
 pipe = StableDiffusionPipeline.from_pretrained(
-	model,
+	st['model'],
 	#vae = AutoencoderKL.from_pretrained("stabilityai/sd-vae-ft-mse"), #this breaks with fp16
 	#custom_pipeline = "waifu-research-department/long-prompt-weighting-pipeline",
-	torch_dtype = torch.float16 if fp16 else torch.float32,
+	torch_dtype = torch.float16 if st['fp16'] else torch.float32,
 	safety_checker = None, #prevents loading the safety checker to save ram, disabled below anyway
 )
 
@@ -70,28 +93,22 @@ pipe.safety_checker = dummy
 # Recommended if your computer has < 64 GB of RAM
 pipe.enable_attention_slicing("max")
 
-if(sampler == "ddim"):
-	pipe.scheduler = DDIMScheduler.from_config(pipe.scheduler.config)
-elif(sampler == "dpm_solver"): 
-	pipe.scheduler = DDIMScheduler.from_config(pipe.scheduler.config)
-elif(sampler == "euler_a"):
-	pipe.scheduler = EulerAncestralDiscreteScheduler.from_config(pipe.scheduler.config)
-elif(sampler == "euler"):
-	pipe.scheduler = EulerAncestralDiscreteScheduler.from_config(pipe.scheduler.config)
-elif(sampler == "lms"):
-	pipe.scheduler = LMSDiscreteScheduler.from_config(pipe.scheduler.config)
-elif(sampler == "pndm"):
-	pipe.scheduler = PNDMScheduler.from_config(pipe.scheduler.config)
-elif(sampler == "dpm2"):
-	pipe.scheduler = KDPM2DiscreteScheduler.from_config(pipe.scheduler.config)
-elif(sampler == "dpm2_a"):
-	pipe.scheduler = KDPM2AncestralDiscreteScheduler.from_config(pipe.scheduler.config)
-elif(sampler == "dpm_solver_m"):
-	pipe.scheduler = DPMSolverMultistepScheduler.from_config(pipe.scheduler.config)
-elif(sampler == "dpm_solver_s"):
-	pipe.scheduler = DPMSolverSinglestepScheduler.from_config(pipe.scheduler.config)
-else:
-	print("invalid sampler")
+sampler_dict = {"ddim":       DDIMScheduler.from_config(pipe.scheduler.config),
+				"dpm_solver": DDIMScheduler.from_config(pipe.scheduler.config),
+				"euler_a": EulerAncestralDiscreteScheduler.from_config(pipe.scheduler.config),
+				"euler":   EulerAncestralDiscreteScheduler.from_config(pipe.scheduler.config),
+				"lms":  LMSDiscreteScheduler.from_config(pipe.scheduler.config),
+				"pndm": PNDMScheduler.from_config(pipe.scheduler.config),
+				"dpm2": KDPM2DiscreteScheduler.from_config(pipe.scheduler.config),
+				"dpm2_a": KDPM2AncestralDiscreteScheduler.from_config(pipe.scheduler.config),
+				"dpm_solver_m": DPMSolverMultistepScheduler.from_config(pipe.scheduler.config),
+				"dpm_solver_s": DPMSolverSinglestepScheduler.from_config(pipe.scheduler.config)
+				}
+
+try:
+	pipe.scheduler = sampler_dict[st['sampler']]
+except KeyError:
+	print(f"{st['sampler']} - invalid sampler")
 	exit()
 
 warnings.filterwarnings("ignore")
@@ -143,17 +160,17 @@ print('\033[0m')
 
 while True: #keeps going until you stop it with ^c
 	seed = random.randint(0, 4294967294)
-	print(f"generating with seed: " + '\033[92m' + f"{seed}" + '\033[0m' + f" at {width}x{height} ({width * height / 1000000}Mpx)")
+	print(f"generating with seed: " + '\033[92m' + f"{seed}" + '\033[0m' + f" at {st['width']}x{st['height']} ({st['width'] * st['height'] / 1000000}Mpx)")
 	generator = torch.Generator("cpu").manual_seed(seed)
 	conditioning = compel.build_conditioning_tensor(f"{invoke_prompt}")
 	neg_conditioning = compel.build_conditioning_tensor(f"{invoke_neg}")
 	image = pipe(
 		prompt_embeds = conditioning, 
 		negative_prompt_embeds = neg_conditioning, 
-		height = int(height), 
-		width = int(width), 
-		guidance_scale = cfg_scale, 
-		num_inference_steps = steps, 
+		height = st['height'], 
+		width = st['width'], 
+		guidance_scale = st['cfg_scale'], 
+		num_inference_steps = st['steps'], 
 		generator=generator
 	).images[0]
 	md = PngInfo()
@@ -165,7 +182,7 @@ while True: #keeps going until you stop it with ^c
 	md.add_text("agent", f"diffusers_test.py")
 	md.add_text('sd-metadata',
 		'{"model": "stable diffusion", "model_weights": "'
-		+ model +
+		+ st['model'] +
 		'", "model_hash": "", "app_id": "'
 		+ "diffusers_test.py" +
 		'", "app_version": "'
@@ -173,16 +190,16 @@ while True: #keeps going until you stop it with ^c
 		'", "image": {"prompt": [{"prompt": "'
 		+ f"{invoke_prompt} [{invoke_neg}]" +
 		'", "weight": 1.0}], "steps": '
-		+ str(steps) +
+		+ str(st['steps']) +
 		', "cfg_scale": '
-		+ str(cfg_scale) +
+		+ str(st['cfg_scale']) +
 		', "threshold": 0.0, "hires_fix": false, "seamless": false, "perlin": 0.0, "width": '
-		+ str(width) +
+		+ str(st['width']) +
 		', "height": '
-		+ str(height) +
+		+ str(st['height']) +
 		', "seed": '
 		+ str(seed) +
 		', "type": "txt2img", "postprocessing": [{"type": "none"}], "sampler": "'
-		+ sampler +
+		+ st['sampler'] +
 		'", "variations": []}}')
 	image.save(f"{seed}.png", pnginfo=md)

--- a/profiles.ini
+++ b/profiles.ini
@@ -1,0 +1,24 @@
+[DEFAULT]
+model = runwayml/stable-diffusion-v1-5
+width = 512
+height = 512
+cfg_scale = 7.5
+steps = 50
+sampler = euler
+fp16 = True
+
+[less-steps]
+steps = 22
+
+[more-cfg]
+steps = 22
+cfg-scale = 11.0
+
+[full-precision]
+fp16 = False
+steps = 16
+
+[wide]
+width = 704
+steps = 22
+


### PR DESCRIPTION
example CLI usage:
`python mps_diffusers.py --profile less-steps -p "a gleaming golden dragon statue" -n "night, indoors, mall"`
can use the `-h` flag to view the args - may want to update profiles.ini (I made this before I saw the new samplers added). Profile and negative prompt are optional, but positive prompt is required.

Also: currently it keeps the `while True` looping, but I could add a 'number of generations' flag to the args if needed. Also will add more args to override the .ini settings if present in the future.